### PR TITLE
Handle gigabyte and unlimited PHP memory limits.

### DIFF
--- a/lib/Varien/Image/Adapter/Gd2.php
+++ b/lib/Varien/Image/Adapter/Gd2.php
@@ -68,6 +68,9 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
     protected function _isMemoryLimitReached()
     {
         $limit = $this->_convertToByte(ini_get('memory_limit'));
+	if ($limit === -1) {
+            return false;
+	}
         $size = getimagesize($this->_fileName);
         $requiredMemory = $size[0] * $size[1] * 3;
         return (memory_get_usage(true) + $requiredMemory) > $limit;
@@ -82,7 +85,9 @@ class Varien_Image_Adapter_Gd2 extends Varien_Image_Adapter_Abstract
      */
     protected function _convertToByte($memoryValue)
     {
-        if (stripos($memoryValue, 'M') !== false) {
+        if (stripos($memoryValue, 'G') !== false) {
+            return (int)$memoryValue * 1024 * 1024 * 1024;
+        } elseif (stripos($memoryValue, 'M') !== false) {
             return (int)$memoryValue * 1024 * 1024;
         } elseif (stripos($memoryValue, 'KB') !== false) {
             return (int)$memoryValue * 1024;


### PR DESCRIPTION
I have added support for memory limits specified in gigabytes and also unlimited memory limits in the GD2 adapter.

Without this fix magento silently (apart from the exception log) to import the images when importing products.
