### PR TITLE
Fix: XML-RPC API cannot return arrays

### DIFF
--- a/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
+++ b/app/code/core/Mage/Api/Model/Server/Handler/Abstract.php
@@ -575,6 +575,13 @@ abstract class Mage_Api_Model_Server_Handler_Abstract
      */
     public function processingRow($row)
     {
+        if (is_array($row)) {
+            $newrow = array();
+            foreach ($row as $i => $subrow) {
+                $newrow[$i] = $this->processingRow($subrow);
+            }
+            return $newrow;
+        }
         $row = preg_replace_callback(
             '/[^\x{0009}\x{000a}\x{000d}\x{0020}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]/u',
             function ($matches) {


### PR DESCRIPTION
I discovered a bug in how Magento 1.9.3 handles arrays in API responses using XML-RPC.
Details here:
https://community.magento.com/t5/Technical-Issues/Bug-XML-RPC-API-cannot-return-arrays/m-p/53422#M4712

I am not sure if this is the correct channel to submit this fix to.
If it is the correct channel: please leave feedback on the code, it can probably be rewritten in a more idiomatic way (I am not very familiar with Magento or PHP).