### PR TITLE
Bug Fix of curlOptions function 

### DIFF
--- a/downloader/lib/Mage/HTTP/Client/Curl.php
+++ b/downloader/lib/Mage/HTTP/Client/Curl.php
@@ -522,7 +522,7 @@ implements Mage_HTTP_IClient
      */
     protected function curlOptions($array)
     {
-        curl_setopt_array($this->_ch, $arr);
+        curl_setopt_array($this->_ch, $array);
     }
 
     /**


### PR DESCRIPTION
fixed use of undefined variable in downloader/lib/Mage/HTTP/Client/Curl.php 