### PR TITLE
Remove extra double quote (")

### DIFF
--- a/app/locale/en_US/template/email/sales/creditmemo_new.html
+++ b/app/locale/en_US/template/email/sales/creditmemo_new.html
@@ -28,7 +28,7 @@
                 <tr>
                     <td class="email-heading">
                         <h1>Thank you for your order from {{var store.getFrontendName()}}.</h1>
-                        <p>You can check the status of your order by <a href="{{store url="customer/account/"}}"">logging into your account</a>.</p>
+                        <p>You can check the status of your order by <a href="{{store url="customer/account/"}}">logging into your account</a>.</p>
                     </td>
                     <td class="store-info">
                         <h4>Order Questions?</h4>

--- a/app/locale/en_US/template/email/sales/creditmemo_new_guest.html
+++ b/app/locale/en_US/template/email/sales/creditmemo_new_guest.html
@@ -27,7 +27,7 @@
                 <tr>
                     <td class="email-heading">
                         <h1>Thank you for your order from {{var store.getFrontendName()}}.</h1>
-                        <p>You can check the status of your order by <a href="{{store url="customer/account/"}}"">logging into your account</a>.</p>
+                        <p>You can check the status of your order by <a href="{{store url="customer/account/"}}">logging into your account</a>.</p>
                     </td>
                     <td class="store-info">
                         <h4>Order Questions?</h4>

--- a/app/locale/en_US/template/email/sales/shipment_new.html
+++ b/app/locale/en_US/template/email/sales/shipment_new.html
@@ -29,7 +29,7 @@
                 <tr>
                     <td class="email-heading">
                         <h1>Thank you for your order from {{var store.getFrontendName()}}.</h1>
-                        <p>You can check the status of your order by <a href="{{store url="customer/account/"}}"">logging into your account</a>.</p>
+                        <p>You can check the status of your order by <a href="{{store url="customer/account/"}}">logging into your account</a>.</p>
                     </td>
                     <td class="store-info">
                         <h4>Order Questions?</h4>

--- a/app/locale/en_US/template/email/sales/shipment_new_guest.html
+++ b/app/locale/en_US/template/email/sales/shipment_new_guest.html
@@ -28,7 +28,7 @@
                 <tr>
                     <td class="email-heading">
                         <h1>Thank you for your order from {{var store.getFrontendName()}}.</h1>
-                        <p>You can check the status of your order by <a href="{{store url="customer/account/"}}"">logging into your account</a>.</p>
+                        <p>You can check the status of your order by <a href="{{store url="customer/account/"}}">logging into your account</a>.</p>
                     </td>
                     <td class="store-info">
                         <h4>Order Questions?</h4>


### PR DESCRIPTION
Fix HTML tagging issue because of extra **_double quote mark_ (")** found in 4 templates:
1. creditmemo_new.html
2. creditmemo_new_guest.html
3. shipment_new.html
4. shipment_new_guest.html