### PR TITLE
Add misssing form key enable check for saveOrderAction()

### DIFF
--- a/app/code/core/Mage/Checkout/controllers/OnepageController.php
+++ b/app/code/core/Mage/Checkout/controllers/OnepageController.php
@@ -562,7 +562,7 @@ class Mage_Checkout_OnepageController extends Mage_Checkout_Controller_Action
      */
     public function saveOrderAction()
     {
-        if (!$this->_validateFormKey()) {
+        if ($this->isFormkeyValidationOnCheckoutEnabled() && !$this->_validateFormKey()) {
             $this->_redirect('*/*');
             return;
         }


### PR DESCRIPTION
If form key validation is disabled for checkout, the order can't saved at last checkout step. 
The saveOrder URL give you in that case a 302 redirect without error messages. 

A additional check if this option is enabled, solved the problem.