### PR TITLE
Update Api.php

### DIFF
--- a/app/code/core/Mage/Directory/Model/Region/Api.php
+++ b/app/code/core/Mage/Directory/Model/Region/Api.php
@@ -53,7 +53,7 @@ class Mage_Directory_Model_Region_Api extends Mage_Api_Model_Resource_Abstract
 
         $result = array();
         foreach ($country->getRegions() as $region) {
-            $region->getName();
+            $region->setName($region->getName());
             $result[] = $region->toArray(array('region_id', 'code', 'name'));
         }
 


### PR DESCRIPTION
Region list request returns null if there is no name value. This way we return default_name instead if it exists.
Can also be patched this way:

foreach ($country->getRegions() as $region) {
    $result[] = $region->toArray(array('region_id', 'code', $region->getName());));
}