### PR TITLE
add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "openmage/magento-mirror",
+    "type": "magento-core",
+    "license": ["OSL-3.0", "AFL-3.0"],
+    "description": "Magento CE"
+}


### PR DESCRIPTION
I've found your repo since firegento decided to archive theirs in favour of your repos. Would you mind adding a composer.json file here in this mirror repo for us who are not yet ready to migrate to LTS?  It would help us be able to still use composer for updating our current installations until June 2020 while preparing to migrate to LTS. 

Our other choice would be to maintain our own fork of this repo but I think it would be better to add it here and declare on packagist. 