### PR TITLE
Fix email/admin_new_user_notification template

### DIFF
--- a/app/locale/en_US/template/email/admin_new_user_notification.html
+++ b/app/locale/en_US/template/email/admin_new_user_notification.html
@@ -3,7 +3,7 @@
 {"store url=\"\"":"Store Url",
 "var logo_url":"Email Logo Image Url",
 "var logo_alt":"Email Logo Image Alt",
-"htmlescape var=$user.name":"New Admin Name",
+"htmlescape var=$user.name":"New Admin Name"}
 @-->
 
 <!--@styles


### PR DESCRIPTION
Issue added in 1.9.3.10

Fix Decoding failed: Syntax error
Someone missed a } in the template @vars header

This should allow users to load this template in the "System -> Transactional Emails" area.