### PR TITLE
update vies vat validation soap endpoint

### DIFF
--- a/app/code/core/Mage/Customer/Helper/Data.php
+++ b/app/code/core/Mage/Customer/Helper/Data.php
@@ -71,7 +71,7 @@ class Mage_Customer_Helper_Data extends Mage_Core_Helper_Abstract
      * WSDL of VAT validation service
      *
      */
-    const VAT_VALIDATION_WSDL_URL = 'http://ec.europa.eu/taxation_customs/vies/services/checkVatService?wsdl';
+    const VAT_VALIDATION_WSDL_URL = 'http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl';
 
     /**
      * Configuration path to expiration period of reset password link


### PR DESCRIPTION
default endpoint for vat validation throught vies webservice defined in VAT_VALIDATION_WSDL_URL
return 302 redirect to http://taxudp92.cc.cec.eu.int:7174/taxation_customs/vies/checkVatService.wsdl
updated this official endpoint http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl